### PR TITLE
🔧 Don't include objective-c files in linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.h linguist-detectable=true
+*.h linguist-documentation=false


### PR DESCRIPTION
Hey @LinusS1! So I remember a while back you said you found it annoying that this repo is marked as objective-c because of sparkle and not swift so I fixed it! That .gitattributes file can configure linguist, the tool that GitHub uses to check repo languages. In this case, I disabled all files that have the `.h` extension. Not a huge change but hope this helped!