### PR TITLE
Fix brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ Post [Scrapbook](https://scrapbook.hackclub.com) updates right from your menu ba
 
 ### 🍻 Homebrew cask
 
-1. Run `brew tap LinusS1/homebrew-tap`
-2. Run `brew cask install scrapple`
-
+1. Run `brew install --cask LinusS1/taps/scrapple`
 
 ## ✈️ Features
  - 🔌 Quick connecting with Slack: it opens the default broswer and has you sign into slack. Then through deep links, it is able to get it's authorization code.


### PR DESCRIPTION
Change:
1. `brew tap LinusS1/homebrew-tap` to `brew tap LinusS1/tap`
2. `brew tap LinusS1/tap` to `brew tap LinusS1/taps`
3. `brew cask install scrapple` to `brew install --cask scrapple`
4. Combine both commands, 
`brew tap LinusS1/taps` and `brew install --cask scrapple`
to
`brew install --cask LinusS1/taps/scrapple`